### PR TITLE
#154: Fix non-exists adhoc task

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ GPL v3
 Change Log
 ----------
 
+* 5.0, release 2 2024.07.25
+    * Fixed issue with the sharing cart unable to handle non-exists task when pressing "Run now" button.
+    * Fixed error when sharing cart try to request a non-exists item from plugin.
 * 5.0, release 1 2024.03.21
     * Total refactor of the whole plugin:
         * Improvements

--- a/classes/app/repository.php
+++ b/classes/app/repository.php
@@ -33,9 +33,11 @@ abstract class repository
 
     public function get_by_id(int $id): false|entity
     {
-        return $this->map_record_to_entity(
-            $this->db->get_record($this->get_table(), ['id' => $id])
-        );
+        $record = $this->db->get_record($this->get_table(), ['id' => $id]);
+        if (!$record) {
+            return false;
+        }
+        return $this->map_record_to_entity($record);
     }
 
     public function insert(entity $entity): int

--- a/classes/external/task/run_now.php
+++ b/classes/external/task/run_now.php
@@ -10,8 +10,6 @@ defined('MOODLE_INTERNAL') || die();
 use core_external\external_api;
 use core_external\external_description;
 use core_external\external_function_parameters;
-use core_external\external_single_structure;
-use core_external\external_multiple_structure;
 use core_external\external_value;
 
 class run_now extends external_api
@@ -44,9 +42,12 @@ class run_now extends external_api
                 'faildelay' => 0,
                 'timestarted' => null,
                 'userid' => $USER->id
-            ],
-            strictness: MUST_EXIST
+            ]
         );
+
+        if (!$task) {
+            return false;
+        }
 
         ob_start();
         \core\task\manager::run_adhoc_from_cli($task->id);

--- a/version.php
+++ b/version.php
@@ -6,7 +6,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var object $plugin */
 $plugin->component = 'block_sharing_cart';
-$plugin->version = 2024032115;
+$plugin->version = 2024072500;
 $plugin->requires = 2023042400; // Moodle 4.2.0
-$plugin->release = '5.0, release 1';
+$plugin->release = '5.0, release 2';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Changes:
* Fix unable to (Run now) on non-exists adhoc task.
* Fix error when sharing cart try to poll non-exists item from plugin.